### PR TITLE
fix: add missing backticks in template literal

### DIFF
--- a/countdown.js
+++ b/countdown.js
@@ -44,7 +44,7 @@ let seconds = minutes*60
 let widget = new ListWidget()
 
 widget.backgroundColor = colorBack
-let countdown = widget.addText(${days})
+let countdown = widget.addText(`${days}`)
 countdown.font = new Font("ArialRoundedMTBold", fontDays, "bold")
 countdown.textColor = colorText
 widget.addSpacer(2)


### PR DESCRIPTION
## Fix

**Issue**: Line 47 had `widget.addText(${days})` instead of `widget.addText(`${days}`)` — missing backticks around template literal.

**Fix**: Added backticks around `${days}` template literal expression.

**Verification**: 1 commit, +1/-1, surgical change. GH007 compliant.

Fixes #2